### PR TITLE
Set c compile flags correctly

### DIFF
--- a/arduino/platform.txt
+++ b/arduino/platform.txt
@@ -19,7 +19,7 @@ recipe.s.o.pattern                   = "{tools.arm_none_eabi_gcc.path}{tools.arm
 ###### Compile c files
 tools.arm_none_eabi_gcc.c.defines    = 
 tools.arm_none_eabi_gcc.c.includes   = 
-tools.arm_none_eabi_gcc.c.cflags     = 
+tools.arm_none_eabi_gcc.c.cflags     = -c -g3 -gdwarf-2 -Os -mcpu=cortex-m3 -mthumb -w -std=gnu99 -fno-common -fmessage-length=0 -Wall -fno-exceptions -fno-builtin-malloc -fno-builtin-free -fno-builtin-realloc -ffunction-sections -fdata-sections -fomit-frame-pointer -nostdlib --param max-inline-insns-single=500 -fno-exceptions -fno-rtti
 tools.arm_none_eabi_gcc.c.conlyflags = 
 recipe.c.o.pattern                   = "{tools.arm_none_eabi_gcc.path}{tools.arm_none_eabi_gcc.gcc}" -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} {tools.arm_none_eabi_gcc.c.defines} {includes} {tools.arm_none_eabi_gcc.c.includes} {tools.arm_none_eabi_gcc.c.cflags} {tools.arm_none_eabi_gcc.c.conlyflags} -c -o "{object_file}" "{source_file}"
 


### PR DESCRIPTION
To support projects with C files.

Based on settings previous to commit 145219332a057558590256d33569acd8dc305a94 with extra -mthumb
setting to match C++ compile flags.

With this change to platform.txt file replacing the version at
C:\Users\Username\AppData\Local\Arduino15\packages\RedBear\hardware\STM32F2\0.3.1\platform.txt
projects containg C files can once again be linked and downloaded successfully to the target device.

Fixes Issue #21 